### PR TITLE
Fix TypeScript error: remove unused ExportResponse interface

### DIFF
--- a/receipt-scanner-app/receipt-scanner-frontend/src/api/index.ts
+++ b/receipt-scanner-app/receipt-scanner-frontend/src/api/index.ts
@@ -107,10 +107,6 @@ interface ApiResponse<T = any> {
   data: T | null;
 }
 
-interface ExportResponse {
-  csv_data: string;
-}
-
 class ApiError extends Error {
   constructor(public status: number, public data: any) {
     super(`API Error: ${status}`);


### PR DESCRIPTION
- Remove unused ExportResponse interface from api/index.ts
- Fix TS6196 error: 'ExportResponse' is declared but never used
- Clean up frontend build process

Fixes frontend build failure with exit code 2.